### PR TITLE
Interactive ChatGPT Feedback via Manual Student Trigger

### DIFF
--- a/src/ACAT/chat_with_gpt.py
+++ b/src/ACAT/chat_with_gpt.py
@@ -1,0 +1,61 @@
+import os
+import pandas as pd
+from openai import OpenAI
+from openai.types.chat import ChatCompletionMessageParam
+from student_outcomes import extract_student_outcomes_for_all_courses
+
+
+def chat_with_gpt(client, messages: list[ChatCompletionMessageParam]):
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4.1",
+            messages=messages
+        )
+        return response.choices[0].message.content
+    except Exception as e:
+        return f"⚠️ Error: {e}"
+
+
+def main():
+    api_key = os.getenv("OPENAI_API_KEY") or input("Please enter your OpenAI API key: ").strip()
+    try:
+        client = OpenAI(api_key=api_key)
+        _ = client.models.list()
+        print("✅ Successfully connected to OpenAI API.")
+    except Exception as e:
+        print(f"❌ Failed to connect to OpenAI API: {e}")
+        return
+
+    # 🔹 Load student outcomes but don't send yet
+    student_outcomes = extract_student_outcomes_for_all_courses()
+    print("📁 Student outcomes loaded. Type 'show student' anytime to insert it into the chat.")
+
+    messages: list[ChatCompletionMessageParam] = [
+        {"role": "system", "content": "You are an expert in assessing student learning capabilities based on a likert scale."}
+    ]
+
+    print("\n🔹 ChatGPT Terminal Chat (type 'exit' to quit)")
+
+    while True:
+        user_input = input("\n🧑 You: ").strip()
+
+        if user_input.lower() in ["exit", "quit"]:
+            print("👋 Goodbye!")
+            break
+
+        # ✅ Special trigger to show student outcomes
+        if user_input.lower() in ["show student", "student", "send student"]:
+            formatted = (
+                f"Here is the Likert scale outcome dictionary for an anonymouse student:\n{student_outcomes}\n\n"
+                f"Please Build a learner model of the students capability. Comment on the student's strengths and weaknesses."
+            )
+            messages.append({"role": "user", "content": formatted})
+        else:
+            messages.append({"role": "user", "content": user_input})
+
+        response = chat_with_gpt(client, messages)
+        print(f"\n🤖 ChatGPT: {response}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ACAT/student_outcomes.py
+++ b/src/ACAT/student_outcomes.py
@@ -1,0 +1,43 @@
+import os
+import pandas as pd
+
+# Function to extract outcomes for student 11 across all courses
+def extract_student_outcomes_for_all_courses(base_dir: str = "/workspaces/scthumma-assessment/src/ACAT", student_id: int = 11) -> dict:
+    courses_outcomes = {}
+
+    # Absolute path to the assessment_results directory
+    assessment_results_dir = os.path.join(base_dir, "assessment_results")
+    
+    # Check if the folder exists
+    if not os.path.exists(assessment_results_dir):
+        print(f"❌ Folder {assessment_results_dir} does not exist.")
+        return courses_outcomes
+
+    # Loop through all files in the assessment_results directory
+    for file_name in os.listdir(assessment_results_dir):
+        if file_name.endswith("_outcomes.xlsx"):  # Check for outcome files
+            course_code = file_name.split("_")[0]  # Extract course code (e.g., "COMP-101")
+            file_path = os.path.join(assessment_results_dir, file_name)
+
+            try:
+                # Read the Excel file
+                df = pd.read_excel(file_path)
+
+                # Filter for Student ID 11 (assuming Student ID is in the first column)
+                student_row = df[df.iloc[:, 0] == student_id]
+
+                if not student_row.empty:
+                    # Extract the outcome-Likert scores into a dictionary (skip the first column)
+                    outcome_dict = student_row.iloc[0, 1:].to_dict()  # Outcomes start from the second column
+                    courses_outcomes[course_code] = outcome_dict
+                else:
+                    print(f"No data found for student {student_id} in course {course_code}")
+
+            except Exception as e:
+                print(f"Error processing file {file_path}: {e}")
+
+    return courses_outcomes
+
+# Example usage: Call the function to extract outcomes for student 11 across all courses
+student_outcomes = extract_student_outcomes_for_all_courses()
+print(student_outcomes)


### PR DESCRIPTION
This update improves the ChatGPT interaction workflow by:

- Loading the student outcome dictionary in the background.
- Allowing the user to manually trigger sending the data to ChatGPT using a specific command (`show student`).
- Preventing automatic data submission to GPT at the start of the session.
- Giving the user full control over when and how to discuss student performance.

This makes the system more interactive and user-driven, preparing it for multi-student or multi-course expansion in the future.
